### PR TITLE
added default svg-loaders-svg className to loaders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svg-loaders-react",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/svg-loader-components/audio.js
+++ b/src/svg-loader-components/audio.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Audio = ({ className, ...props }) => (
-  <svg width={55} height={80} fill="#FFF" className={`svg-loaders-svg${className ? ` ${className}`:''}`} {...props}>
+  <svg width={55} height={80} fill="#FFF" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <g transform="matrix(1 0 0 -1 0 80)">
       <rect width={10} height={20} rx={3}>
         <animate
@@ -48,12 +48,12 @@ const Audio = ({ className, ...props }) => (
   </svg>
 );
 
-Audio.propTypes={
+Audio.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Audio.defaultProps={
+Audio.defaultProps = {
   className: undefined,
-}
+};
 
 export { Audio };

--- a/src/svg-loader-components/audio.js
+++ b/src/svg-loader-components/audio.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Audio = props => (
-  <svg width={55} height={80} fill="#FFF" {...props}>
+const Audio = ({className, ...props}) => (
+  <svg width={55} height={80} fill="#FFF" className={`svg-loaders-svg${className?` ${className}`:''}`} {...props}>
     <g transform="matrix(1 0 0 -1 0 80)">
       <rect width={10} height={20} rx={3}>
         <animate

--- a/src/svg-loader-components/audio.js
+++ b/src/svg-loader-components/audio.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Audio = ({className, ...props}) => (
-  <svg width={55} height={80} fill="#FFF" className={`svg-loaders-svg${className?` ${className}`:''}`} {...props}>
+const Audio = ({ className, ...props }) => (
+  <svg width={55} height={80} fill="#FFF" className={`svg-loaders-svg${className ? ` ${className}`:''}`} {...props}>
     <g transform="matrix(1 0 0 -1 0 80)">
       <rect width={10} height={20} rx={3}>
         <animate
@@ -46,5 +47,13 @@ const Audio = ({className, ...props}) => (
     </g>
   </svg>
 );
+
+Audio.propTypes={
+  className: PropTypes.string,
+}
+
+Audio.defaultProps={
+  className: undefined,
+}
 
 export { Audio };

--- a/src/svg-loader-components/ball-triangle.js
+++ b/src/svg-loader-components/ball-triangle.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const BallTriangle =({className, ...props})=> (
-  <svg width={57} height={57} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const BallTriangle = ({ className, ...props }) => (
+  <svg width={57} height={57} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <g
       transform="translate(1 1)"
       strokeWidth={2}
@@ -71,5 +72,13 @@ const BallTriangle =({className, ...props})=> (
     </g>
   </svg>
 );
+
+BallTriangle.propTypes={
+  className: PropTypes.string,
+}
+
+BallTriangle.defaultProps={
+  className: undefined,
+}
 
 export { BallTriangle };

--- a/src/svg-loader-components/ball-triangle.js
+++ b/src/svg-loader-components/ball-triangle.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const BallTriangle = props => (
-  <svg width={57} height={57} stroke="#fff" {...props}>
+const BallTriangle =({className, ...props})=> (
+  <svg width={57} height={57} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <g
       transform="translate(1 1)"
       strokeWidth={2}

--- a/src/svg-loader-components/ball-triangle.js
+++ b/src/svg-loader-components/ball-triangle.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const BallTriangle = ({ className, ...props }) => (
-  <svg width={57} height={57} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={57} height={57} stroke="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <g
       transform="translate(1 1)"
       strokeWidth={2}
@@ -73,12 +73,12 @@ const BallTriangle = ({ className, ...props }) => (
   </svg>
 );
 
-BallTriangle.propTypes={
+BallTriangle.propTypes = {
   className: PropTypes.string,
-}
+};
 
-BallTriangle.defaultProps={
+BallTriangle.defaultProps = {
   className: undefined,
-}
+};
 
 export { BallTriangle };

--- a/src/svg-loader-components/bars.js
+++ b/src/svg-loader-components/bars.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Bars = ({ className, ...props }) => (
-  <svg width={135} height={140} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={135} height={140} fill="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <rect y={10} width={15} height={120} rx={6}>
       <animate
         attributeName="height"
@@ -96,12 +96,12 @@ const Bars = ({ className, ...props }) => (
   </svg>
 );
 
-Bars.propTypes={
+Bars.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Bars.defaultProps={
+Bars.defaultProps = {
   className: undefined,
-}
+};
 
 export { Bars };

--- a/src/svg-loader-components/bars.js
+++ b/src/svg-loader-components/bars.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Bars = ({className, ...props}) => (
-  <svg width={135} height={140} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Bars = ({ className, ...props }) => (
+  <svg width={135} height={140} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <rect y={10} width={15} height={120} rx={6}>
       <animate
         attributeName="height"
@@ -94,5 +95,13 @@ const Bars = ({className, ...props}) => (
     </rect>
   </svg>
 );
+
+Bars.propTypes={
+  className: PropTypes.string,
+}
+
+Bars.defaultProps={
+  className: undefined,
+}
 
 export { Bars };

--- a/src/svg-loader-components/bars.js
+++ b/src/svg-loader-components/bars.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Bars = props => (
-  <svg width={135} height={140} fill="#fff" {...props}>
+const Bars = ({className, ...props}) => (
+  <svg width={135} height={140} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <rect y={10} width={15} height={120} rx={6}>
       <animate
         attributeName="height"

--- a/src/svg-loader-components/circles.js
+++ b/src/svg-loader-components/circles.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Circles = ({ className, ...props }) => (
-  <svg width={135} height={135} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={135} height={135} fill="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <path d="M67.447 58c5.523 0 10-4.477 10-10s-4.477-10-10-10-10 4.477-10 10 4.477 10 10 10zm9.448 9.447c0 5.523 4.477 10 10 10 5.522 0 10-4.477 10-10s-4.478-10-10-10c-5.523 0-10 4.477-10 10zm-9.448 9.448c-5.523 0-10 4.477-10 10 0 5.522 4.477 10 10 10s10-4.478 10-10c0-5.523-4.477-10-10-10zM58 67.447c0-5.523-4.477-10-10-10s-10 4.477-10 10 4.477 10 10 10 10-4.477 10-10z">
       <animateTransform
         attributeName="transform"
@@ -26,12 +26,12 @@ const Circles = ({ className, ...props }) => (
   </svg>
 );
 
-Circles.propTypes={
+Circles.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Circles.defaultProps={
+Circles.defaultProps = {
   className: undefined,
-}
+};
 
 export { Circles };

--- a/src/svg-loader-components/circles.js
+++ b/src/svg-loader-components/circles.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Circles =({className, ...props}) => (
-  <svg width={135} height={135} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Circles = ({ className, ...props }) => (
+  <svg width={135} height={135} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <path d="M67.447 58c5.523 0 10-4.477 10-10s-4.477-10-10-10-10 4.477-10 10 4.477 10 10 10zm9.448 9.447c0 5.523 4.477 10 10 10 5.522 0 10-4.477 10-10s-4.478-10-10-10c-5.523 0-10 4.477-10 10zm-9.448 9.448c-5.523 0-10 4.477-10 10 0 5.522 4.477 10 10 10s10-4.478 10-10c0-5.523-4.477-10-10-10zM58 67.447c0-5.523-4.477-10-10-10s-10 4.477-10 10 4.477 10 10 10 10-4.477 10-10z">
       <animateTransform
         attributeName="transform"
@@ -24,5 +25,13 @@ const Circles =({className, ...props}) => (
     </path>
   </svg>
 );
+
+Circles.propTypes={
+  className: PropTypes.string,
+}
+
+Circles.defaultProps={
+  className: undefined,
+}
 
 export { Circles };

--- a/src/svg-loader-components/circles.js
+++ b/src/svg-loader-components/circles.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Circles = props => (
-  <svg width={135} height={135} fill="#fff" {...props}>
+const Circles =({className, ...props}) => (
+  <svg width={135} height={135} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <path d="M67.447 58c5.523 0 10-4.477 10-10s-4.477-10-10-10-10 4.477-10 10 4.477 10 10 10zm9.448 9.447c0 5.523 4.477 10 10 10 5.522 0 10-4.477 10-10s-4.478-10-10-10c-5.523 0-10 4.477-10 10zm-9.448 9.448c-5.523 0-10 4.477-10 10 0 5.522 4.477 10 10 10s10-4.478 10-10c0-5.523-4.477-10-10-10zM58 67.447c0-5.523-4.477-10-10-10s-10 4.477-10 10 4.477 10 10 10 10-4.477 10-10z">
       <animateTransform
         attributeName="transform"

--- a/src/svg-loader-components/grid.js
+++ b/src/svg-loader-components/grid.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Grid = ({ className, ...props }) => (
-  <svg width={105} height={105} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}`}  {...props}>
+  <svg width={105} height={105} fill="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <circle cx={12.5} cy={12.5} r={12.5}>
       <animate
         attributeName="fill-opacity"
@@ -96,12 +96,12 @@ const Grid = ({ className, ...props }) => (
   </svg>
 );
 
-Grid.propTypes={
+Grid.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Grid.defaultProps={
+Grid.defaultProps = {
   className: undefined,
-}
+};
 
 export { Grid };

--- a/src/svg-loader-components/grid.js
+++ b/src/svg-loader-components/grid.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Grid = props => (
-  <svg width={105} height={105} fill="#fff" {...props}>
+const Grid = ({className, ...props}) => (
+  <svg width={105} height={105} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <circle cx={12.5} cy={12.5} r={12.5}>
       <animate
         attributeName="fill-opacity"

--- a/src/svg-loader-components/grid.js
+++ b/src/svg-loader-components/grid.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Grid = ({className, ...props}) => (
-  <svg width={105} height={105} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Grid = ({ className, ...props }) => (
+  <svg width={105} height={105} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}`}  {...props}>
     <circle cx={12.5} cy={12.5} r={12.5}>
       <animate
         attributeName="fill-opacity"
@@ -94,5 +95,13 @@ const Grid = ({className, ...props}) => (
     </circle>
   </svg>
 );
+
+Grid.propTypes={
+  className: PropTypes.string,
+}
+
+Grid.defaultProps={
+  className: undefined,
+}
 
 export { Grid };

--- a/src/svg-loader-components/hearts.js
+++ b/src/svg-loader-components/hearts.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Hearts = ({className, ...props}) => (
-  <svg width={140} height={64} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Hearts = ({ className, ...props }) => (
+  <svg width={140} height={64} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <path
       d="M30.262 57.02L7.195 40.723c-5.84-3.976-7.56-12.06-3.842-18.063 3.715-6 11.467-7.65 17.306-3.68l4.52 3.76 2.6-5.274c3.717-6.002 11.47-7.65 17.305-3.68 5.84 3.97 7.56 12.054 3.842 18.062L34.49 56.118c-.897 1.512-2.793 1.915-4.228.9z"
       fillOpacity={0.5}
@@ -31,4 +32,12 @@ const Hearts = ({className, ...props}) => (
     <path d="M67.408 57.834l-23.01-24.98c-5.864-6.15-5.864-16.108 0-22.248 5.86-6.14 15.37-6.14 21.234 0L70 16.168l4.368-5.562c5.863-6.14 15.375-6.14 21.235 0 5.863 6.14 5.863 16.098 0 22.247l-23.007 24.98c-1.43 1.556-3.757 1.556-5.188 0z" />
   </svg>
 );
+Hearts.propTypes={
+  className: PropTypes.string,
+}
+
+Hearts.defaultProps={
+  className: undefined,
+}
+
 export { Hearts };

--- a/src/svg-loader-components/hearts.js
+++ b/src/svg-loader-components/hearts.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Hearts = props => (
-  <svg width={140} height={64} fill="#fff" {...props}>
+const Hearts = ({className, ...props}) => (
+  <svg width={140} height={64} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <path
       d="M30.262 57.02L7.195 40.723c-5.84-3.976-7.56-12.06-3.842-18.063 3.715-6 11.467-7.65 17.306-3.68l4.52 3.76 2.6-5.274c3.717-6.002 11.47-7.65 17.305-3.68 5.84 3.97 7.56 12.054 3.842 18.062L34.49 56.118c-.897 1.512-2.793 1.915-4.228.9z"
       fillOpacity={0.5}

--- a/src/svg-loader-components/hearts.js
+++ b/src/svg-loader-components/hearts.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Hearts = ({ className, ...props }) => (
-  <svg width={140} height={64} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={140} height={64} fill="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <path
       d="M30.262 57.02L7.195 40.723c-5.84-3.976-7.56-12.06-3.842-18.063 3.715-6 11.467-7.65 17.306-3.68l4.52 3.76 2.6-5.274c3.717-6.002 11.47-7.65 17.305-3.68 5.84 3.97 7.56 12.054 3.842 18.062L34.49 56.118c-.897 1.512-2.793 1.915-4.228.9z"
       fillOpacity={0.5}
@@ -32,12 +32,12 @@ const Hearts = ({ className, ...props }) => (
     <path d="M67.408 57.834l-23.01-24.98c-5.864-6.15-5.864-16.108 0-22.248 5.86-6.14 15.37-6.14 21.234 0L70 16.168l4.368-5.562c5.863-6.14 15.375-6.14 21.235 0 5.863 6.14 5.863 16.098 0 22.247l-23.007 24.98c-1.43 1.556-3.757 1.556-5.188 0z" />
   </svg>
 );
-Hearts.propTypes={
+Hearts.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Hearts.defaultProps={
+Hearts.defaultProps = {
   className: undefined,
-}
+};
 
 export { Hearts };

--- a/src/svg-loader-components/oval.js
+++ b/src/svg-loader-components/oval.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Oval = props => (
-  <svg width={38} height={38} stroke="#fff" {...props}>
+const Oval = ({className, ...props}) => (
+  <svg width={38} height={38} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <g
       transform="translate(1 1)"
       strokeWidth={2}

--- a/src/svg-loader-components/oval.js
+++ b/src/svg-loader-components/oval.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Oval = ({ className, ...props }) => (
-  <svg width={38} height={38} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={38} height={38} stroke="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <g
       transform="translate(1 1)"
       strokeWidth={2}
@@ -25,12 +25,12 @@ const Oval = ({ className, ...props }) => (
 );
 
 
-Oval.propTypes={
+Oval.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Oval.defaultProps={
+Oval.defaultProps = {
   className: undefined,
-}
+};
 
 export { Oval };

--- a/src/svg-loader-components/oval.js
+++ b/src/svg-loader-components/oval.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Oval = ({className, ...props}) => (
-  <svg width={38} height={38} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Oval = ({ className, ...props }) => (
+  <svg width={38} height={38} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <g
       transform="translate(1 1)"
       strokeWidth={2}
@@ -23,5 +24,13 @@ const Oval = ({className, ...props}) => (
   </svg>
 );
 
+
+Oval.propTypes={
+  className: PropTypes.string,
+}
+
+Oval.defaultProps={
+  className: undefined,
+}
 
 export { Oval };

--- a/src/svg-loader-components/puff.js
+++ b/src/svg-loader-components/puff.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Puff = ({ className, ...props }) => (
-  <svg width={44} height={44} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={44} height={44} stroke="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <g fill="none" fillRule="evenodd" strokeWidth={2}>
       <circle cx={22} cy={22} r={1}>
         <animate
@@ -52,12 +52,12 @@ const Puff = ({ className, ...props }) => (
   </svg>
 );
 
-Puff.propTypes={
+Puff.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Puff.defaultProps={
+Puff.defaultProps = {
   className: undefined,
-}
+};
 
 export { Puff };

--- a/src/svg-loader-components/puff.js
+++ b/src/svg-loader-components/puff.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Puff = props => (
-  <svg width={44} height={44} stroke="#fff" {...props}>
+const Puff = ({className, ...props}) => (
+  <svg width={44} height={44} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <g fill="none" fillRule="evenodd" strokeWidth={2}>
       <circle cx={22} cy={22} r={1}>
         <animate

--- a/src/svg-loader-components/puff.js
+++ b/src/svg-loader-components/puff.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Puff = ({className, ...props}) => (
-  <svg width={44} height={44} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Puff = ({ className, ...props }) => (
+  <svg width={44} height={44} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <g fill="none" fillRule="evenodd" strokeWidth={2}>
       <circle cx={22} cy={22} r={1}>
         <animate
@@ -50,5 +51,13 @@ const Puff = ({className, ...props}) => (
     </g>
   </svg>
 );
+
+Puff.propTypes={
+  className: PropTypes.string,
+}
+
+Puff.defaultProps={
+  className: undefined,
+}
 
 export { Puff };

--- a/src/svg-loader-components/rings.js
+++ b/src/svg-loader-components/rings.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const Rings = ({className, ...props}) => (
-  <svg width={45} height={45} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const Rings = ({ className, ...props }) => (
+  <svg width={45} height={45} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <g
       fill="none"
       fillRule="evenodd"
@@ -73,5 +74,13 @@ const Rings = ({className, ...props}) => (
     </g>
   </svg>
 );
+
+Rings.propTypes={
+  className: PropTypes.string,
+}
+
+Rings.defaultProps={
+  className: undefined,
+}
 
 export { Rings };

--- a/src/svg-loader-components/rings.js
+++ b/src/svg-loader-components/rings.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const Rings = props => (
-  <svg width={45} height={45} stroke="#fff" {...props}>
+const Rings = ({className, ...props}) => (
+  <svg width={45} height={45} stroke="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <g
       fill="none"
       fillRule="evenodd"

--- a/src/svg-loader-components/rings.js
+++ b/src/svg-loader-components/rings.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Rings = ({ className, ...props }) => (
-  <svg width={45} height={45} stroke="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={45} height={45} stroke="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <g
       fill="none"
       fillRule="evenodd"
@@ -75,12 +75,12 @@ const Rings = ({ className, ...props }) => (
   </svg>
 );
 
-Rings.propTypes={
+Rings.propTypes = {
   className: PropTypes.string,
-}
+};
 
-Rings.defaultProps={
+Rings.defaultProps = {
   className: undefined,
-}
+};
 
 export { Rings };

--- a/src/svg-loader-components/spinning-circles.js
+++ b/src/svg-loader-components/spinning-circles.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SpinningCircles = ({ className, ...props }) => (
-  <svg width={58} height={58} className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={58} height={58} className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <g
       transform="translate(2 1)"
       stroke="#FFF"
@@ -94,12 +94,12 @@ const SpinningCircles = ({ className, ...props }) => (
   </svg>
 );
 
-SpinningCircles.propTypes={
+SpinningCircles.propTypes = {
   className: PropTypes.string,
-}
+};
 
-SpinningCircles.defaultProps={
+SpinningCircles.defaultProps = {
   className: undefined,
-}
+};
 
 export { SpinningCircles };

--- a/src/svg-loader-components/spinning-circles.js
+++ b/src/svg-loader-components/spinning-circles.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const SpinningCircles = props => (
-  <svg width={58} height={58} {...props}>
+const SpinningCircles = ({className, ...props}) => (
+  <svg width={58} height={58} className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <g
       transform="translate(2 1)"
       stroke="#FFF"

--- a/src/svg-loader-components/spinning-circles.js
+++ b/src/svg-loader-components/spinning-circles.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const SpinningCircles = ({className, ...props}) => (
-  <svg width={58} height={58} className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const SpinningCircles = ({ className, ...props }) => (
+  <svg width={58} height={58} className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <g
       transform="translate(2 1)"
       stroke="#FFF"
@@ -92,5 +93,13 @@ const SpinningCircles = ({className, ...props}) => (
     </g>
   </svg>
 );
+
+SpinningCircles.propTypes={
+  className: PropTypes.string,
+}
+
+SpinningCircles.defaultProps={
+  className: undefined,
+}
 
 export { SpinningCircles };

--- a/src/svg-loader-components/tail-spin.js
+++ b/src/svg-loader-components/tail-spin.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const TailSpin = ({className, ...props}) => (
-  <svg width={38} height={38} className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const TailSpin = ({ className, ...props }) => (
+  <svg width={38} height={38} className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <defs>
       <linearGradient
         x1="8.042%"
@@ -43,5 +44,13 @@ const TailSpin = ({className, ...props}) => (
     </g>
   </svg>
 );
+
+TailSpin.propTypes={
+  className: PropTypes.string,
+}
+
+TailSpin.defaultProps={
+  className: undefined,
+}
 
 export { TailSpin };

--- a/src/svg-loader-components/tail-spin.js
+++ b/src/svg-loader-components/tail-spin.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const TailSpin = props => (
-  <svg width={38} height={38} {...props}>
+const TailSpin = ({className, ...props}) => (
+  <svg width={38} height={38} className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <defs>
       <linearGradient
         x1="8.042%"

--- a/src/svg-loader-components/tail-spin.js
+++ b/src/svg-loader-components/tail-spin.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const TailSpin = ({ className, ...props }) => (
-  <svg width={38} height={38} className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={38} height={38} className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <defs>
       <linearGradient
         x1="8.042%"
@@ -45,12 +45,12 @@ const TailSpin = ({ className, ...props }) => (
   </svg>
 );
 
-TailSpin.propTypes={
+TailSpin.propTypes = {
   className: PropTypes.string,
-}
+};
 
-TailSpin.defaultProps={
+TailSpin.defaultProps = {
   className: undefined,
-}
+};
 
 export { TailSpin };

--- a/src/svg-loader-components/three-dots.js
+++ b/src/svg-loader-components/three-dots.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const ThreeDots = props => (
-  <svg width={120} height={30} fill="#fff" {...props}>
+const ThreeDots = ({className, ...props}) => (
+  <svg width={120} height={30} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
     <circle cx={15} cy={15} r={15}>
       <animate
         attributeName="r"

--- a/src/svg-loader-components/three-dots.js
+++ b/src/svg-loader-components/three-dots.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ThreeDots = ({ className, ...props }) => (
-  <svg width={120} height={30} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
+  <svg width={120} height={30} fill="#fff" className={`svg-loaders-svg${className ? ` ${className}` : ''}`} {...props}>
     <circle cx={15} cy={15} r={15}>
       <animate
         attributeName="r"
@@ -72,12 +72,12 @@ const ThreeDots = ({ className, ...props }) => (
   </svg>
 );
 
-ThreeDots.propTypes={
+ThreeDots.propTypes = {
   className: PropTypes.string,
-}
+};
 
-ThreeDots.defaultProps={
+ThreeDots.defaultProps = {
   className: undefined,
-}
+};
 
 export { ThreeDots };

--- a/src/svg-loader-components/three-dots.js
+++ b/src/svg-loader-components/three-dots.js
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const ThreeDots = ({className, ...props}) => (
-  <svg width={120} height={30} fill="#fff" className={`svg-loaders-svg${className?` ${className}`:''}`}  {...props}>
+const ThreeDots = ({ className, ...props }) => (
+  <svg width={120} height={30} fill="#fff" className={`svg-loaders-svg${ className ? ` ${className}`:''}` }  {...props}>
     <circle cx={15} cy={15} r={15}>
       <animate
         attributeName="r"
@@ -70,5 +71,13 @@ const ThreeDots = ({className, ...props}) => (
     </circle>
   </svg>
 );
+
+ThreeDots.propTypes={
+  className: PropTypes.string,
+}
+
+ThreeDots.defaultProps={
+  className: undefined,
+}
 
 export { ThreeDots };


### PR DESCRIPTION
as per this feature request

https://github.com/ajwann/svg-loaders-react/issues/30

created a PR with the feature itself.

this adds a default `className="svg-loaders-svg"` to all the loaders and still allows final users to make use of the className prop by appending their className after the default one (automatically handles the whitespace if final user defines a className)